### PR TITLE
Adding some edge-case unit tests for MaterializedEnumerable

### DIFF
--- a/MindTouchMaterializedEnumerableAnalyzer/MindTouchMaterializedEnumerableAnalyzer/MaterializedCollectionsUtils.cs
+++ b/MindTouchMaterializedEnumerableAnalyzer/MindTouchMaterializedEnumerableAnalyzer/MaterializedCollectionsUtils.cs
@@ -38,9 +38,10 @@ namespace MindTouchMaterializedEnumerableAnalyzer {
                 var methodCallInfo = semanticModel.GetSymbolInfo(argument);
                 if((methodCallInfo.Symbol != null) && (methodCallInfo.Symbol.Kind == SymbolKind.Method)) {
                     var mSymbol = (IMethodSymbol)methodCallInfo.Symbol;
+                    var typeInfo = semanticModel.GetTypeInfo(argument);
 
                     // If the method is not an extension method, we assume it returned a materialized collection
-                    return mSymbol.IsExtensionMethod && mSymbol.ContainingNamespace.ToDisplayString().Equals("System.Linq");
+                    return IsAbstractCollectionType(typeInfo) && mSymbol.IsExtensionMethod && mSymbol.ContainingNamespace.ToDisplayString().Equals("System.Linq");
                 }
                 break;
             case SyntaxKind.IdentifierName:


### PR DESCRIPTION
Adding some edge-case unit tests for MaterializedEnumerable:

Should be detected as materialized based on last assignment:
```
public void Test() {
    IEnumerable<int> l1;
    l1 = new List().Select(x => x+x);
    l1 = l1.ToArray();
    Add(l1, l1);
}
```

Should be detected as un-materialized based on last assignment:
```
public void Test() {
    IEnumerable<int> l1;
    l1 = l1.ToArray();
    l1 = new List().Select(x => x+x);
    Add(l1, l1);
}